### PR TITLE
Remove workaround for setup master node

### DIFF
--- a/ironic.patch
+++ b/ironic.patch
@@ -1,0 +1,12 @@
+diff --git a/system_test/tests/actions_base.py b/system_test/tests/actions_base.py
+index 0d3959a..c865b2a 100644
+--- a/system_test/tests/actions_base.py
++++ b/system_test/tests/actions_base.py
+@@ -218,6 +218,7 @@ class ActionsBase(PrepareBase, HealthCheckActions, PluginsActions):
+             "sahara": self.env_settings['components'].get('sahara', False),
+             "ceilometer": self.env_settings['components'].get('ceilometer',
+                                                               False),
++            "ironic": self.env_settings['components'].get('ironic', False),
+             "user": self.env_config.get("user", "admin"),
+             "password": self.env_config.get("password", "admin"),
+             "tenant": self.env_config.get("tenant", "admin"),


### PR DESCRIPTION
This patch apply ironic changes (if possible) to any branch of fuel-qa.
Also FUEL_DEVOPS version is removed, because it fixed in fuel-qa
requirements file.