### PR TITLE
Add fuel_qa patching before run

### DIFF
--- a/deploy_env.sh
+++ b/deploy_env.sh
@@ -223,12 +223,16 @@ cp ${CONFIG_NAME} fuel-qa/system_test/tests_templates/tests_configs
 
 cd fuel-qa
 
-# Apply ironic patch
-git apply --check ../ironic.patch 2> /dev/null
-if [ $? -eq 0 ]; then
-    echo "Patching for ironic"
-    git apply ../ironic.patch
-fi
+# Apply fuel-qa patches
+for p in $(ls ../fuel_qa_patches); do
+    patch_file=../fuel_qa_patches/$p
+    echo "Check for patch $p"
+    git apply --check $patch_file 2> /dev/null
+    if [ $? -eq 0 ]; then
+        echo "Applying patch $p"
+        git apply $patch_file
+    fi
+done
 
 # create new environment
 # more time can be required to deploy env

--- a/fuel_qa_patches/DVR_L2_pop_HA.patch
+++ b/fuel_qa_patches/DVR_L2_pop_HA.patch
@@ -1,0 +1,74 @@
+From 103146770e8dfe4abf39f7559b955ef0c3ee9008 Mon Sep 17 00:00:00 2001
+From: Alexander Gromov <agromov@mirantis.com>
+Date: Thu, 31 Dec 2015 14:59:22 +0300
+Subject: [PATCH] Added DVR, L2 population and L3 agents HA support.
+
+Added possibility to deploy environments with DVR, L2 population and L3 agents HA
+(Neutron options) to system tests templates in fuel-qa.
+
+Change-Id: I45b9a2b96cd7af218c4715cec0c7478b5d7bb387
+Closes-Bug: #1529230
+---
+
+diff --git a/fuelweb_test/models/fuel_web_client.py b/fuelweb_test/models/fuel_web_client.py
+index b585cf2..c95bb4a 100644
+--- a/fuelweb_test/models/fuel_web_client.py
++++ b/fuelweb_test/models/fuel_web_client.py
+@@ -480,6 +480,9 @@
+                     section = 'access'
+                 if option == 'assign_to_all_nodes':
+                     section = 'public_network_assignment'
++                if option in ('neutron_l3_ha', 'neutron_dvr',
++                              'neutron_l2_pop'):
++                    section = 'neutron_advanced_configuration'
+                 if option in 'dns_list':
+                     section = 'external_dns'
+                 if option in 'ntp_list':
+@@ -488,6 +491,26 @@
+                     attributes['editable'][section][option]['value'] =\
+                         settings[option]
+ 
++            # we should check DVR limitations
++            section = 'neutron_advanced_configuration'
++            if attributes['editable'][section]['neutron_dvr']['value']:
++                if attributes['editable'][section]['neutron_l3_ha']['value']:
++                    raise Exception("Neutron DVR and Neutron L3 HA can't be"
++                                    " used simultaneously.")
++
++                if 'net_segment_type' in settings:
++                    net_segment_type = settings['net_segment_type']
++                elif NEUTRON_SEGMENT_TYPE:
++                    net_segment_type = NEUTRON_SEGMENT[NEUTRON_SEGMENT_TYPE]
++                else:
++                    net_segment_type = None
++
++                if not attributes['editable'][section]['neutron_l2_pop'][
++                        'value'] and net_segment_type == 'tun':
++                    raise Exception("neutron_l2_pop is not enabled but "
++                                    "it is required for VxLAN DVR "
++                                    "network configuration.")
++
+             public_gw = self.environment.d_env.router(router_name="public")
+ 
+             remote = self.environment.d_env.get_admin_remote()
+diff --git a/system_test/tests/actions_base.py b/system_test/tests/actions_base.py
+index bf30d23..8046433 100644
+--- a/system_test/tests/actions_base.py
++++ b/system_test/tests/actions_base.py
+@@ -239,8 +239,15 @@
+                                                                'vlan'),
+             "assign_to_all_nodes": self.env_config['network'].get(
+                 'pubip-to-all',
+-                False)
++                False),
++            "neutron_l3_ha": self.env_config['network'].get(
++                'neutron-l3-ha', False),
++            "neutron_dvr": self.env_config['network'].get(
++                'neutron-dvr', False),
++            "neutron_l2_pop": self.env_config['network'].get(
++                'neutron-l2-pop', False)
+         }
++
+         self.cluster_id = self.fuel_web.create_cluster(
+             name=self.env_config['name'],
+             mode=test_settings.DEPLOYMENT_MODE,

--- a/fuel_qa_patches/ironic.patch
+++ b/fuel_qa_patches/ironic.patch
@@ -1,8 +1,19 @@
+From d5d99fad5cda783e57707a9545dba8411bf0cb1f Mon Sep 17 00:00:00 2001
+From: Alexander Gromov <agromov@mirantis.com>
+Date: Sat, 23 Jan 2016 22:47:12 +0300
+Subject: [PATCH] Added Ironic support for configs.
+
+Added possibility to deploy environments with Ironic using yaml templates.
+
+Change-Id: I5e6264057e6a3e50f50e03605ae9f8125744b02e
+Closes-Bug: #1534559
+---
+
 diff --git a/system_test/tests/actions_base.py b/system_test/tests/actions_base.py
-index 0d3959a..c865b2a 100644
+index d2365dc..99d8fb4 100644
 --- a/system_test/tests/actions_base.py
 +++ b/system_test/tests/actions_base.py
-@@ -218,6 +218,7 @@ class ActionsBase(PrepareBase, HealthCheckActions, PluginsActions):
+@@ -218,6 +218,7 @@
              "sahara": self.env_settings['components'].get('sahara', False),
              "ceilometer": self.env_settings['components'].get('ceilometer',
                                                                False),


### PR DESCRIPTION
Stable branches of fuel_qa doesn't contain some important features, like
deployment with L3 HA from templates. This patch adds possibility to
apply patches to fuel_qa, if they are applicable.