### PR TITLE
Adding correct version of Fuel-QA repository

### DIFF
--- a/jenkins-job-builder/maintenance/create_env_parametrized_maintenance_6.1.yaml
+++ b/jenkins-job-builder/maintenance/create_env_parametrized_maintenance_6.1.yaml
@@ -59,7 +59,7 @@
           default: "2.9.16"
       - string:
           name: FUEL_QA_VER
-          default: "master"
+          default: "stable/6.1"
       - string:
           name: MASTER_IS_CENTOS7
           default: "FALSE"

--- a/jenkins-job-builder/maintenance/create_env_parametrized_maintenance_7.0.yaml
+++ b/jenkins-job-builder/maintenance/create_env_parametrized_maintenance_7.0.yaml
@@ -59,7 +59,7 @@
           default: "2.9.16"
       - string:
           name: FUEL_QA_VER
-          default: "master"
+          default: "stable/7.0"
       - string:
           name: MASTER_IS_CENTOS7
           default: "FALSE"


### PR DESCRIPTION
Correct version of the Fuel QA repository has been added for both 6.1
and 7.0 version of the MOS