### PR TITLE
Remote DRIVER_USE_HOST_CPU parameter in maintenance jobs

### DIFF
--- a/jenkins-job-builder/maintenance/7.0/builders/maintenance_deploy_env_7_0.sh
+++ b/jenkins-job-builder/maintenance/7.0/builders/maintenance_deploy_env_7_0.sh
@@ -167,7 +167,6 @@ fi
 # create new environment
 # more time can be required to deploy env
 export DEPLOYMENT_TIMEOUT=10000
-export DRIVER_USE_HOST_CPU=false
 export ENV_NAME=$ENV_NAME
 
 ./utils/jenkins/system_tests.sh -k -K -j fuelweb_test -t test -w $(pwd) -e "$ENV_NAME" -o --group="$GROUP" -i "$ISO_PATH"


### PR DESCRIPTION
Removed DRIVER_USE_HOST_CPU=false for KVMs in
maintenance jobs.