### PR TITLE
updated glance template with default murano

### DIFF
--- a/templates/glance/ceph.yaml
+++ b/templates/glance/ceph.yaml
@@ -18,7 +18,7 @@ template:
       components:
         ceilometer: false
         ironic: false
-        murano: false
+        murano: true
         sahara: false
       storages:
         ephemeral-ceph: true

--- a/templates/glance/swift.yaml
+++ b/templates/glance/swift.yaml
@@ -20,7 +20,7 @@ template:
       components:
         ceilometer: false
         ironic: false
-        murano: false
+        murano: true 
         sahara: false
       storages:
         ephemeral-ceph: false


### PR DESCRIPTION
Added default murano to the fuel config to have possibility to run the tests on the same environment with glance without re-deployment.